### PR TITLE
Wire up Round 1 voice dictation end-to-end

### DIFF
--- a/server/routes/parse.js
+++ b/server/routes/parse.js
@@ -35,6 +35,7 @@ router.post("/", async (req, res) => {
     return res.status(400).json({ error: "round is required and must be a number" });
   }
 
+  console.log("[parse] Round:", round, "Transcript:", transcript.slice(0, 100));
   try {
     const message = await getClient().messages.create({
       model: "claude-haiku-4-5-20251001",
@@ -52,6 +53,7 @@ router.post("/", async (req, res) => {
       return res.status(502).json({ error: "Unexpected response format from Claude" });
     }
 
+    console.log("[parse] Result:", JSON.stringify(parsed));
     res.json(parsed);
   } catch (err) {
     console.error("Parse failed:", err.message);

--- a/server/routes/transcribe.js
+++ b/server/routes/transcribe.js
@@ -16,8 +16,9 @@ router.post("/", upload.single("audio"), async (req, res) => {
     return res.status(400).json({ error: "No audio file provided" });
   }
 
+  console.log("[transcribe] Received file:", req.file.originalname, req.file.mimetype, req.file.size, "bytes");
   try {
-    const file = new File([req.file.buffer], req.file.originalname, {
+    const file = await OpenAI.toFile(req.file.buffer, req.file.originalname, {
       type: req.file.mimetype,
     });
 
@@ -26,6 +27,7 @@ router.post("/", upload.single("audio"), async (req, res) => {
       file,
     });
 
+    console.log("[transcribe] Result:", text);
     res.json({ transcript: text });
   } catch (err) {
     console.error("Transcription failed:", err.message);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import TeamInput from './components/TeamInput';
 import RankingList from './components/RankingList/RankingList';
 import DownloadCSV from './components/DownloadCSV';
 import DictateButton from './components/DictateButton';
+import { processDictation } from './services/dictation';
 import './App.css';
 
 function App() {
@@ -13,6 +14,28 @@ function App() {
   const [round2Rankings, setRound2Rankings] = useState([]);
   const [currentRound, setCurrentRound] = useState(1);
   const [setupComplete, setSetupComplete] = useState(false);
+  const [isDictating, setIsDictating] = useState(false);
+  const [dictationError, setDictationError] = useState(null);
+
+  const handleDictationComplete = async (audioBlob) => {
+    setIsDictating(true);
+    setDictationError(null);
+    try {
+      const results = await processDictation(audioBlob, currentRound, []);
+      const newTeams = results.map(({ name, score }) => ({
+        name,
+        round1: String(score),
+        round2: '',
+      }));
+      setTeams(newTeams);
+      setSetupComplete(true);
+    } catch (err) {
+      console.error('Dictation failed:', err);
+      setDictationError(err.message);
+    } finally {
+      setIsDictating(false);
+    }
+  };
 
   const setupInitialTeams = (numberOfTeams) => {
     const initialTeams = Array(numberOfTeams).fill().map(() => ({ name: '', round1: '', round2: '' }));
@@ -108,7 +131,17 @@ function App() {
     <div className="App">
       <h1>trivia-tool-2 v1.2 🎙️</h1>
       {!setupComplete ? (
-        <InitialTeamSetup onSetupComplete={setupInitialTeams} />
+        <div>
+          <InitialTeamSetup onSetupComplete={setupInitialTeams} />
+          {currentRound === 1 && (
+            <div className="dictate-section">
+              <p>Or dictate scores by voice:</p>
+              <DictateButton onRecordingComplete={handleDictationComplete} />
+              {isDictating && <p className="processing-text">Processing audio...</p>}
+              {dictationError && <p className="error-text">Error: {dictationError}</p>}
+            </div>
+          )}
+        </div>
       ) : (
         <>
           <TeamInput 
@@ -120,10 +153,16 @@ function App() {
             <button onClick={addTeam} className="add-team">&#43;</button>
             <button onClick={removeTeam} className="remove-team">&#8722;</button>
           </div>
-          <DictateButton onRecordingComplete={(blob) => {
-            console.log('Recording complete:', blob.type, blob.size, 'bytes');
-          }} />
-          <button onClick={rankTeams}>Rank Teams</button>
+          {currentRound === 1 && (
+            <>
+              <DictateButton onRecordingComplete={handleDictationComplete} />
+              {isDictating && <p className="processing-text">Processing audio...</p>}
+              {dictationError && <p className="error-text">Error: {dictationError}</p>}
+            </>
+          )}
+          <button onClick={rankTeams} disabled={isDictating}>
+            {isDictating ? 'Processing...' : 'Rank Teams'}
+          </button>
             {currentRound === 1 && round1Rankings.length > 0 && (
               <button onClick={startRound2}>Start Round 2</button>
             )}

--- a/src/components/DictateButton.jsx
+++ b/src/components/DictateButton.jsx
@@ -55,10 +55,9 @@ function DictateButton({ onRecordingComplete }) {
         streamRef.current = null;
 
         setState('processing');
-        setTimeout(() => {
-          onRecordingComplete(blob);
+        Promise.resolve(onRecordingComplete(blob)).finally(() => {
           setState('idle');
-        }, 600);
+        });
       };
 
       recorder.start();

--- a/src/services/dictation.js
+++ b/src/services/dictation.js
@@ -1,0 +1,42 @@
+function extensionForMime(mime) {
+  if (mime.includes('mp4')) return 'mp4';
+  if (mime.includes('ogg')) return 'ogg';
+  return 'webm';
+}
+
+export async function processDictation(audioBlob, round, existingTeams) {
+  // Step 1: Transcribe audio
+  const ext = extensionForMime(audioBlob.type);
+  const formData = new FormData();
+  formData.append('audio', audioBlob, `recording.${ext}`);
+
+  const transcribeRes = await fetch('/api/transcribe', {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!transcribeRes.ok) {
+    const err = await transcribeRes.json().catch(() => ({}));
+    throw new Error(err.error || `Transcription failed (HTTP ${transcribeRes.status})`);
+  }
+
+  const { transcript } = await transcribeRes.json();
+  console.log('[dictation] Transcript:', transcript);
+
+  // Step 2: Parse transcript into team/score pairs
+  console.log('[dictation] Parsing transcript for round', round);
+  const parseRes = await fetch('/api/parse', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ transcript, round, existingTeams }),
+  });
+
+  if (!parseRes.ok) {
+    const err = await parseRes.json().catch(() => ({}));
+    throw new Error(err.error || 'Parsing failed');
+  }
+
+  const parsed = await parseRes.json();
+  console.log('[dictation] Parsed results:', parsed);
+  return parsed;
+}


### PR DESCRIPTION
  Add dictation service that sends audio to /api/transcribe then /api/parse,
  and integrate it into App.jsx so dictated scores populate the teams state
  and bypass manual setup. DictateButton now awaits the async callback before
  returning to idle. Fix transcribe route to use OpenAI.toFile for proper
  buffer handling. Add request/response logging to both server routes.